### PR TITLE
Update run-kibot.yml

### DIFF
--- a/.github/workflows/run-kibot.yml
+++ b/.github/workflows/run-kibot.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: INTI-CMNB/KiBot@v2_k6
+    - uses: INTI-CMNB/KiBot@v2_k7
       with:
         # Required - kibot config file
         config: main.kibot.yaml


### PR DESCRIPTION
This change sets the kibot workflow to use kicad v7 to match your local version. This allows the automated workflow to update the PCB preview in the main readme file when you change the pcb.